### PR TITLE
feat: use official speedtest and style scrollbars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ COPY requirements.txt .
 
 # Install system dependencies for network tools and Python requirements
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    iputils-ping mtr \
+    iputils-ping mtr curl \
+    && curl -s https://install.speedtest.net/app/cli/install.deb.sh | bash \
+    && apt-get install -y --no-install-recommends speedtest \
     && rm -rf /var/lib/apt/lists/* \
     && pip install --no-cache-dir -r requirements.txt
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ console-web 是一个使用 [Flask](https://flask.palletsprojects.com/) 和 [psu
 
 ## 本地运行
 ```bash
-pip install flask psutil speedtest-cli
+pip install flask psutil
+# 安装官方 Speedtest CLI：https://www.speedtest.net/apps/cli
 python app/main.py
 ```
 应用默认监听在 `http://127.0.0.1:8080`。页面中提供 Ping、MTR、SpeedTest 按钮，可实时查看执行结果。
@@ -32,7 +33,7 @@ chmod +x deploy.sh
 ```
 脚本会自动克隆仓库、构建镜像并在 8180 端口运行容器。运行时如未输入指令，将在 3 秒倒计时后默认重新部署，部署完成后会自动显示可访问的服务器 IP。
 
-镜像内已预装 `iputils-ping`、`mtr` 和 `speedtest-cli`，因此 Web 终端提供的网络诊断命令可开箱即用。
+镜像内已预装 `iputils-ping`、`mtr` 和 官方 `speedtest` CLI，因此 Web 终端提供的网络诊断命令可开箱即用。
 
 ## 目录结构
 ```

--- a/app/main.py
+++ b/app/main.py
@@ -39,7 +39,13 @@ PING_TARGETS = {
 COMMANDS = {
     "ping": lambda target: ["ping", "-c", "4", target],
     "mtr": lambda target: ["mtr", "-w", "-c", "5", target],
-    "speedtest": lambda target: ["speedtest-cli", "--simple"],
+    # Use the official Speedtest CLI instead of the Python speedtest-cli
+    "speedtest": lambda target: [
+        "speedtest",
+        "--progress=no",
+        "--accept-license",
+        "--accept-gdpr",
+    ],
 }
 
 @app.route("/run/<cmd>")
@@ -157,6 +163,32 @@ TEMPLATE = r"""
         .terminal-input {
             background: black; color: #00FF00; font-family: 'Consolas', monospace;
             border: none; outline: none; caret-color: #00FF00; caret-shape: block;
+        }
+        /* Custom scrollbar styling */
+        .stats::-webkit-scrollbar,
+        #cmd_output::-webkit-scrollbar {
+            width: 8px;
+        }
+        .stats::-webkit-scrollbar-track,
+        #cmd_output::-webkit-scrollbar-track {
+            background: #001100;
+        }
+        .stats::-webkit-scrollbar-thumb,
+        #cmd_output::-webkit-scrollbar-thumb {
+            background: #00FF00;
+            border-radius: 4px;
+        }
+        .stats::-webkit-scrollbar-thumb:hover,
+        #cmd_output::-webkit-scrollbar-thumb:hover {
+            background: #00cc00;
+        }
+        .stats {
+            scrollbar-color: #00FF00 #001100;
+            scrollbar-width: thin;
+        }
+        #cmd_output {
+            scrollbar-color: #00FF00 #001100;
+            scrollbar-width: thin;
         }
         @media (max-width: 600px) {
             .window { width: 100%; padding: 10px; }
@@ -346,7 +378,7 @@ To exit reality, press ALT+F4. Good luck.
     function runCommand(cmd, target = '') {
         if (currentSource) currentSource.close();
         const output = document.getElementById('cmd_output');
-        const commandText = target ? `${cmd} ${target}` : cmd === 'speedtest' ? 'speedtest-cli --simple' : cmd;
+        const commandText = target ? `${cmd} ${target}` : cmd;
         output.insertAdjacentText('beforeend', `${PROMPT} ${commandText}\n`);
         output.scrollTop = output.scrollHeight;
         let url = `/run/${cmd}`;

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 flask
 psutil
-speedtest-cli
 


### PR DESCRIPTION
## Summary
- switch to official Speedtest CLI and drop Python speedtest-cli dependency
- add themed scrollbars for stats and command output
- document Speedtest CLI usage and update Dockerfile

## Testing
- `python -m py_compile app/main.py`
- `python app/main.py` (fetch `/stats`)
- `docker build -t console-web-test .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e38d54950832ab0e09f65a6f42e27