### PR TITLE
feat: allow CLI arguments for network tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ COPY requirements.txt .
 # Install system dependencies for network tools and Python requirements
 RUN apt-get update && apt-get install -y --no-install-recommends \
     iputils-ping mtr curl \
-
     && curl -L -o /tmp/speedtest.tgz https://install.speedtest.net/app/cli/ookla-speedtest-1.2.0-linux-x86_64.tgz \
     && tar -xzf /tmp/speedtest.tgz -C /usr/local/bin speedtest \
     && rm -rf /var/lib/apt/lists/* /tmp/speedtest.tgz \


### PR DESCRIPTION
## Summary
- support passing extra CLI arguments to ping, mtr, speedtest
- fix Dockerfile line continuation issue

## Testing
- `python -m py_compile app/main.py`
- `docker build -t console-web .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_688e3c755ebc832a90d7ad55a53c0627