### PR TITLE
Add endpoint for URL ping with ISP info

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ console-web 是一个使用 [Flask](https://flask.palletsprojects.com/) 和 [psu
 - 容器与宿主机运行时间
 - 本地/公网 IP、磁盘 IO、网络 IO 以及实时上传/下载速度
 - 对多家运营商的 TCP Ping 监测
+- 查询任意 URL 的 IP、ISP 及 Ping 信息
 - 内置网络工具：Ping、MTR、SpeedTest，支持实时回显
 
 ## 本地运行


### PR DESCRIPTION
## Summary
- expose `/pinginfo` endpoint that resolves a URL, pings it and returns IP, ISP, and latency data
- document the new API in the feature list

## Testing
- `python -m py_compile app/main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e48a0c678832ab0ed2ac0847d5910