### PR TITLE
Remove Speedtest functionality

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,8 @@ COPY requirements.txt .
 
 # Install system dependencies for network tools and Python requirements
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    iputils-ping mtr curl \
-    && curl -L -o /tmp/speedtest.tgz https://install.speedtest.net/app/cli/ookla-speedtest-1.2.0-linux-x86_64.tgz \
-    && tar -xzf /tmp/speedtest.tgz -C /usr/local/bin speedtest \
-    && rm -rf /var/lib/apt/lists/* /tmp/speedtest.tgz \
+    iputils-ping mtr \
+    && rm -rf /var/lib/apt/lists/* \
     && pip install --no-cache-dir -r requirements.txt
 
 # Copy application source

--- a/README.md
+++ b/README.md
@@ -11,17 +11,15 @@ console-web 是一个使用 [Flask](https://flask.palletsprojects.com/) 和 [psu
 - 本地/公网 IP、磁盘 IO、网络 IO 以及实时上传/下载速度
 - 对多家运营商的 TCP Ping 监测
 - 查询任意 URL 的 IP、ISP 及 Ping 信息
-- 内置网络工具：Ping、MTR、SpeedTest，支持实时回显
+- 内置网络工具：Ping、MTR，支持实时回显
 
 ## 本地运行
 ```bash
 pip install flask psutil
 
-# 安装官方 Speedtest CLI（下载并解压官方提供的压缩包）：https://www.speedtest.net/apps/cli
-
 python app/main.py
 ```
-应用默认监听在 `http://127.0.0.1:8080`。页面中提供 Ping、MTR、SpeedTest 按钮，可实时查看执行结果。
+应用默认监听在 `http://127.0.0.1:8080`。页面中提供 Ping、MTR 按钮，可实时查看执行结果。
 
 ## Docker 部署
 可以直接构建镜像：
@@ -37,7 +35,7 @@ chmod +x deploy.sh
 脚本会自动克隆仓库、构建镜像并在 8180 端口运行容器。运行时如未输入指令，将在 3 秒倒计时后默认重新部署，部署完成后会自动显示可访问的服务器 IP。
 
 
-镜像内已预装 `iputils-ping`、`mtr` 和 官方 `speedtest` CLI（通过官方压缩包安装），因此 Web 终端提供的网络诊断命令可开箱即用。
+镜像内已预装 `iputils-ping`、`mtr`，因此 Web 终端提供的网络诊断命令可开箱即用。
 
 
 ## 目录结构

--- a/app/main.py
+++ b/app/main.py
@@ -46,14 +46,6 @@ COMMANDS = {
     "mtr": lambda target, extra: ["mtr", *extra, target]
     if extra
     else ["mtr", "-w", "-c", "5", target],
-    # Use the official Speedtest CLI instead of the Python speedtest-cli
-    "speedtest": lambda target, extra: [
-        "speedtest",
-        "--progress=no",
-        "--accept-license",
-        "--accept-gdpr",
-        *extra,
-    ],
 }
 
 @app.route("/run/<cmd>")
@@ -62,7 +54,7 @@ def run_cmd(cmd):
     raw_args = request.args.get("args", "")
     if cmd not in COMMANDS:
         return Response("unsupported command", status=400)
-    if cmd != "speedtest" and not target:
+    if not target:
         return Response("target required", status=400)
     extra_args = shlex.split(raw_args) if raw_args else []
     try:
@@ -517,15 +509,11 @@ To exit reality, press ALT+F4. Good luck.
                         outputEl.insertAdjacentText('beforeend', `${PROMPT} ${text}\nmissing target\n`);
                     }
                     break;
-                case 'speedtest':
-                    runCommand('speedtest', '', args.join(' '));
-                    break;
                 case 'help':
                     outputEl.insertAdjacentText('beforeend', `${PROMPT} ${text}\n` +
                         'Available commands:\n' +
                         '  ping <host>\n' +
                         '  mtr <host>\n' +
-                        '  speedtest [args]\n' +
                         '  help\n');
                     break;
                 default:


### PR DESCRIPTION
## Summary
- drop Speedtest command and UI references
- stop installing Speedtest CLI in Docker image
- update documentation to remove Speedtest instructions

## Testing
- `python -m py_compile app/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688e5213c02c832a8b6973e5cddd058a