### PR TITLE
Install build dependencies for psutil

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ WORKDIR /app
 COPY requirements.txt .
 
 # Install system dependencies for network tools and Python requirements
-RUN apk add --no-cache iputils mtr \
+# psutil requires compilation, so include build tools and Python headers
+RUN apk add --no-cache iputils mtr build-base python3-dev linux-headers \
     && pip install --no-cache-dir -r requirements.txt
 
 # Copy application source


### PR DESCRIPTION
## Summary
- Install GCC and build tools in Dockerfile so psutil builds correctly on Alpine

## Testing
- `python -m py_compile app/main.py`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_6895c36a7be8832a93ac8f3f28225b9d