### PR TITLE
docs: fix alpine pip install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ python app/main.py
 apk add --no-cache python3 py3-pip git iputils mtr
 git clone https://github.com/podcctv/console-web.git /opt/console-web
 cd /opt/console-web
-pip install -r requirements.txt
+pip install --break-system-packages -r requirements.txt
 python app/main.py
 ```
 


### PR DESCRIPTION
## Summary
- fix Alpine deployment snippet by using `pip install --break-system-packages`

## Testing
- `pip install --break-system-packages -r requirements.txt`
- `python app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6895c5b46484832aba8dc7b6fdde3b14